### PR TITLE
Using 'HashRouter' instead of 'BrowserRouter'

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router-dom'
 import './css/index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <HashRouter basename={import.meta.env.BASE_URL}>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </StrictMode>,
 )

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,7 @@ import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <HashRouter basename={import.meta.env.BASE_URL}>
+    <HashRouter>
       <App />
     </HashRouter>
   </StrictMode>,


### PR DESCRIPTION
In development (localhost), React Router handles routing in memory. Refreshing /favorites still serves index.html and React takes care of rendering the right page.

On GitHub Pages, when you refresh /favorites, GitHub actually looks for a file at /favorites/index.html, doesn’t find it, and returns a 404.

✅ Fixes

 Use HashRouter instead of BrowserRouter
Since GitHub Pages doesn’t support server-side routing, the simplest fix is to use HashRouter.